### PR TITLE
GH #17: Remove reference to missing UI.Popup component

### DIFF
--- a/src/js/views/home.js
+++ b/src/js/views/home.js
@@ -108,10 +108,6 @@ module.exports = React.createClass({
 						</Link>
 					</div>
 				</UI.ViewContent>
-				<UI.Popup visible={this.state.popup.visible}>
-					<UI.PopupIcon name={this.state.popup.iconName} type={this.state.popup.iconType} spinning={this.state.popup.loading} />
-					<strong>{this.state.popup.header}</strong>
-				</UI.Popup>
 			</UI.View>
 		);
 	}


### PR DESCRIPTION
The remove a reference to the UI.Popup component which is missing from the 0.3.2 release. Fixes #17.